### PR TITLE
✨ Allow to update some configuration

### DIFF
--- a/custom_components/aquarea/__init__.py
+++ b/custom_components/aquarea/__init__.py
@@ -6,7 +6,7 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, DeviceType
 
-PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SWITCH]
+PLATFORMS = [Platform.SENSOR, Platform.BINARY_SENSOR, Platform.SWITCH, Platform.SELECT]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/aquarea/select.py
+++ b/custom_components/aquarea/select.py
@@ -1,0 +1,93 @@
+"""Support for HeishaMon controlled heatpumps through MQTT."""
+from __future__ import annotations
+import logging
+
+from homeassistant.components import mqtt
+from homeassistant.components.mqtt.client import async_publish
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import slugify
+
+from .definitions import SELECTS, HeishaMonSelectEntityDescription
+from . import build_device_info
+
+_LOGGER = logging.getLogger(__name__)
+
+# async_setup_platform should be defined if one wants to support config via configuration.yaml
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up HeishaMon sensors from config entry."""
+    async_add_entities(
+        HeishaMonMQTTSelect(hass, description, config_entry) for description in SELECTS
+    )
+
+
+class HeishaMonMQTTSelect(SelectEntity):
+    """Representation of a HeishaMon sensor that is updated via MQTT."""
+
+    entity_description: HeishaMonSelectEntityDescription
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        description: HeishaMonSelectEntityDescription,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize the sensor."""
+        self.entity_description = description
+        self.hass = hass
+
+        slug = slugify(description.key.replace("/", "_"))
+        self.entity_id = f"select.{slug}"
+        self._attr_unique_id = f"{config_entry.entry_id}-{slug}"
+        self._attr_current_option = None
+
+    async def async_select_option(self, option: str) -> None:
+        _LOGGER.debug(
+            f"Changing {self.entity_description.name} to {option} (sent to {self.entity_description.command_topic})"
+        )
+        if self.entity_description.state_to_mqtt is not None:
+            payload = self.entity_description.state_to_mqtt(option)
+        else:
+            payload = option
+        await async_publish(
+            self.hass,
+            self.entity_description.command_topic,
+            payload,
+            self.entity_description.qos,
+            self.entity_description.retain,
+            self.entity_description.encoding,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to MQTT events."""
+
+        @callback
+        def message_received(message):
+            """Handle new MQTT messages."""
+            _LOGGER.debug(
+                f"Received message for {self.entity_description.name}: {message}"
+            )
+            if self.entity_description.state is not None:
+                self._attr_current_option = self.entity_description.state(
+                    message.payload
+                )
+            else:
+                self._attr_current_option = message.payload
+
+            self.async_write_ha_state()
+
+        await mqtt.async_subscribe(
+            self.hass, self.entity_description.key, message_received, 1
+        )
+
+    @property
+    def device_info(self):
+        return build_device_info(self.entity_description.device)

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
   "name": "HeishaMon",
-  "render_readme": true
+  "render_readme": true,
+  "homeassistant": "2022.11.0b0"
 }


### PR DESCRIPTION
By leveraging "select" entities instead of simple sensors, we can now control options that had more than on/off state.
It includes at least QuietMode option

We now requires HA 2022.11 (unreleased at the moment) since we need https://github.com/home-assistant/core/commit/ca9bfc8b861a0987fd097ee5d807fa40427077ff

Change-Id: I89f84bee674425cdbdd6fbea7be90f737089e309