### PR TITLE
⚙ Expose app as a hub

### DIFF
--- a/custom_components/aquarea/manifest.json
+++ b/custom_components/aquarea/manifest.json
@@ -6,6 +6,7 @@
   "issue_tracker": "https://github.com/kamaradclimber/heishamon-homeassistant/issues",
   "dependencies": ["mqtt", "template"],
   "mqtt": ["panasonic_heat_pump/#"],
+  "integration_type": "hub",
   "codeowners": ["@kamaradclimber"],
   "iot_class": "local_push",
   "version": "0.3.0"


### PR DESCRIPTION
Technically we only support a single heatpump but we expose both heishamon device and the heatpump.

Change-Id: I3b0cd8d968f5ca32e29f581519f223b652d2b919