### PR TITLE
🗒 Adjust heatpump mode log severity

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -300,7 +300,10 @@ class HeishaMonZoneClimate(ClimateEntity):
         self.change_mode(ZoneClimateMode.DIRECT, initialization=True)
 
     def change_mode(self, mode: ZoneClimateMode, initialization:bool=False):
-        _LOGGER.warn(f"Changing mode to {mode} for zone {self.zone_id}")
+        if self._mode == mode:
+            _LOGGER.debug(f"Enforcing mode to {mode} for zone {self.zone_id}")
+        else:
+            _LOGGER.info(f"Changing mode to {mode} for zone {self.zone_id}")
         self._mode = mode
         if mode == ZoneClimateMode.COMPENSATION:
             self._attr_min_temp = -5


### PR DESCRIPTION
Using a warning was not necessarily appropriate and scary. For users of direct compensation, we'll still have an info message. Under normal condition, we'll just have a debug message because the method is called only to make sure we normalize all attributes.

Change-Id: I65f3b7456c83b48a408fcb9a07688ca0479e2b34
Reference: https://github.com/kamaradclimber/heishamon-homeassistant/issues/47