### PR TITLE
🐛 Accept wider range of value for heat commands

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -311,7 +311,7 @@ def build_numbers(mqtt_prefix: str) -> list[HeishaMonNumberEntityDescription]:
             on_receive=partial(
                 guess_shift_or_direct_and_clamp_min_max_values,
                 range(-5, 6),
-                range(20, 30),
+                range(7, 45),
             ),
         ),
         HeishaMonNumberEntityDescription(
@@ -350,7 +350,7 @@ def build_numbers(mqtt_prefix: str) -> list[HeishaMonNumberEntityDescription]:
             on_receive=partial(
                 guess_shift_or_direct_and_clamp_min_max_values,
                 range(-5, 6),
-                range(20, 30),
+                range(7, 45),
             ),
         ),
         HeishaMonNumberEntityDescription(


### PR DESCRIPTION
Some heatpumps use those value to drive either room temperature or water temperature.
Until we know how to distinguish those two setups we'll have to widen the range. UX will be weirder since user will be able to see very wide range of possible values.

Fixes #57

Change-Id: I1106a699d03d9172003f5848b9f875442a256d69