### PR TITLE
🐛 Accept wider range of value for climate component

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -311,7 +311,7 @@ class HeishaMonZoneClimate(ClimateEntity):
             self._attr_target_temperature_step = 1
         else:
             self._attr_min_temp = 15
-            self._attr_max_temp = 25
+            self._attr_max_temp = 45
             self._attr_target_temperature_step = 1
         if not initialization:
             # during initialization we cannot write HA state because entities are not registered yet.


### PR DESCRIPTION
In a previous commit (238ce9439ee97d5647da25c0dc79417b34613160) we fixed values accepted by sensors but not the one accepted for the climate component.
It's now done.

Fix #57
Fix #66

Change-Id: Ibc9ad154a60570eb1c4790f61998ce90fc8f84b8