### PR TITLE
🐛 Remove incorrect device class duration

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -751,7 +751,6 @@ def build_sensors(mqtt_prefix: str) -> list[HeishaMonSensorEntityDescription]:
             heishamon_topic_id="TOP12",
             key=f"{mqtt_prefix}main/Operations_Counter",
             name="Aquarea Compressor Start/Stop Counter",
-            device_class=SensorDeviceClass.DURATION,
             state_class=SensorStateClass.TOTAL_INCREASING,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),


### PR DESCRIPTION
Start/Stop is a counter (not a duration)

Fixes #78

Change-Id: I48fa83f6c89024e6b8524cb5518f42cf132fec2b