### PR TITLE
🐛 Suggest precision for energy sensors

### DIFF
--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -265,7 +265,7 @@ class S0Detector(SensorEntity):
                     state_class=SensorStateClass.MEASUREMENT,
                     unit_of_measurement="kWh",
                     native_unit_of_measurement="Wh",
-                    native_precision=0,
+                    suggested_display_precision=0,
                     device=DeviceType.HEISHAMON,
                 )
                 watt_hour_sensor = HeishaMonSensor(
@@ -278,7 +278,7 @@ class S0Detector(SensorEntity):
                     device_class=SensorDeviceClass.ENERGY,
                     unit_of_measurement="kWh",
                     native_unit_of_measurement="Wh",
-                    native_precision=0,
+                    suggested_display_precision=0,
                     state_class=SensorStateClass.TOTAL_INCREASING,
                     device=DeviceType.HEISHAMON,
                 )


### PR DESCRIPTION
This will fix #86 and #87

Option defined in [this
post](https://developers.home-assistant.io/blog/2023/01/25/sensor_rounding/) has been reverted and replaced by a presentation option (instead of rounding the state).

This will implement correctly #52

Change-Id: I122a0e855098e37d38f14cb02f07c3b24a201afc