### PR TITLE
Allow DemandControl entity to be updated

### DIFF
--- a/custom_components/aquarea/number.py
+++ b/custom_components/aquarea/number.py
@@ -58,6 +58,9 @@ class HeishaMonMQTTNumber(NumberEntity):
         self._attr_unique_id = (
             f"{config_entry.entry_id}-{description.heishamon_topic_id}"
         )
+        if self.entity_description.initial_value is not None:
+            self._attr_native_value = self.entity_description.initial_value
+            self.async_write_ha_state()
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(


### PR DESCRIPTION
This is some sort of hack to compensate for the fact we never receive a "first" value for this entity (and HA does not want to update a number with a slider when it's original value is `None`)

Fix #124