### PR TITLE
🐛 Set initial state later in the process

### DIFF
--- a/custom_components/aquarea/number.py
+++ b/custom_components/aquarea/number.py
@@ -58,9 +58,6 @@ class HeishaMonMQTTNumber(NumberEntity):
         self._attr_unique_id = (
             f"{config_entry.entry_id}-{description.heishamon_topic_id}"
         )
-        if self.entity_description.initial_value is not None:
-            self._attr_native_value = self.entity_description.initial_value
-            self.async_write_ha_state()
 
     async def async_set_native_value(self, value: float) -> None:
         _LOGGER.debug(
@@ -81,6 +78,10 @@ class HeishaMonMQTTNumber(NumberEntity):
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""
+
+        if self.entity_description.initial_value is not None:
+            self._attr_native_value = self.entity_description.initial_value
+            self.async_write_ha_state()
 
         @callback
         def message_received(message):


### PR DESCRIPTION
We cannot set native value in entity constructor because the entity has not been added to its platform yet.
It leads to:
> Entity number.panasonic_heat_pump_main_fakedemandcontrol (<class 'custom_components.aquarea.number.HeishaMonMQTTNumber'>) does not have a platform, this may be caused by adding it manually instead of with an EntityComponent helper, please report it to the custom integration author

Solution is to set the value in the entity added to hass callback

This is a partial fix for #127