### PR TITLE
✨ Optimistically update number entity value before sending payload.

### DIFF
--- a/custom_components/aquarea/number.py
+++ b/custom_components/aquarea/number.py
@@ -63,6 +63,10 @@ class HeishaMonMQTTNumber(NumberEntity):
         _LOGGER.debug(
             f"Changing {self.entity_description.name} to {value} (sent to {self.entity_description.command_topic})"
         )
+        # optimisticly change the value
+        self._attr_native_value = value
+        self.async_write_ha_state()
+
         if self.entity_description.state_to_mqtt is not None:
             payload = self.entity_description.state_to_mqtt(value)
         else:


### PR DESCRIPTION
In practice, it should not make any difference because we should receive an update of the corresponding sensor from heishamon. Specifically for DemandControl, we don't receive updates so we need to set this value.