### PR TITLE
🐛 Only react to markers of 3.1/3.2 when relevant

### DIFF
--- a/custom_components/aquarea/update.py
+++ b/custom_components/aquarea/update.py
@@ -100,9 +100,9 @@ class HeishaMonMQTTUpdate(UpdateEntity):
         def message_received(message):
             """Handle new MQTT messages."""
 
-            if message.topic == self.marker3_2_topic:
+            if self.stats_firmware_contain_version == False and message.topic == self.marker3_2_topic:
                 self._attr_installed_version = "3.2"
-            if message.topic == self.marker3_1_and_before_topic:
+            if self.stats_firmware_contain_version == False and message.topic == self.marker3_1_and_before_topic:
                 self._attr_installed_version = "<= 3.1"
             if message.topic == self.entity_description.heishamon_topic_id:
                 field_value = json.loads(message.payload).get("version", None)


### PR DESCRIPTION
Before this patch, a firmware 3.3 (or any custom build) would alternate between 3.2 and the other version. It would happen because stats_firmware_contain_version would be set to true and we would receive markers of version 3.2 as well and update HA state.

Now we ignore mzarkers of 3.1/3.2 until we are sure stats topic does not contain version information

Fix #152