### PR TITLE
🐛 Remove duplicated entity

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -1104,13 +1104,6 @@ def build_sensors(mqtt_prefix: str) -> list[HeishaMonSensorEntityDescription]:
             state_class=SensorStateClass.MEASUREMENT,
         ),
         HeishaMonSensorEntityDescription(
-            heishamon_topic_id="TOP19",
-            key=f"{mqtt_prefix}main/Holiday_Mode_State",
-            name="Aquarea Holiday Mode",
-            entity_category=EntityCategory.CONFIG,
-            state=read_holiday_status,
-        ),
-        HeishaMonSensorEntityDescription(
             heishamon_topic_id="TOP20",
             key=f"{mqtt_prefix}main/ThreeWay_Valve_State",
             name="Aquarea 3-way Valve",


### PR DESCRIPTION
Holiday_Mode_State topic is already reflected in the corresponding switch.

This was raised in #163 since the removed entity is a sensor marked as "config" which is now forbidden (config entities are supposed to be read-write, otherwise they should be marked as diagnostic).

Fix #163