### PR TITLE
switch to Sensor Settings for mode configuration for climate entity

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -86,10 +86,10 @@ class ZoneClimateEntityDescription(ClimateEntityDescription):
 # preparing ZoneSensorMode to handle sensor setting per zone (TOP111 and TOP112)
 # currently not used as ZoneSensorMode change will result directly in ZoneClimateMode change
 class ZoneSensorMode(Enum):
-    WATER = 1
-    EXTERNAL = 2
-    INTERNAL = 3
-    THERMISTOR = 4
+    WATER = 0
+    EXTERNAL = 1
+    INTERNAL = 2
+    THERMISTOR = 3
 
 class ZoneClimateMode(Enum):
     COMPENSATION = 1
@@ -202,16 +202,11 @@ class HeishaMonZoneClimate(ClimateEntity):
         @callback
         def sensor_mode_received(message):
             mode = self._mode
-            if message.payload == "0":
-                sensor_mode = ZoneSensorMode.WATER
-            elif message.payload == "1":
-                sensor_mode = ZoneSensorMode.EXTERNAL
-            elif message.payload == "2":
-                sensor_mode = ZoneSensorMode.INTERNAL
-            elif message.payload == "3":
-                sensor_mode = ZoneSensorMode.THERMISTOR
-            else:
-                assert False, f"Sensor mode received is not a known value"
+            try:
+                sensor_mode = ZoneSensorMode(int(message.payload))
+            except ValueError:
+                _LOGGER.error(f"Sensor mode value {message.payload} is not a valid value")
+                assert False
             if sensor_mode != self._sensor_mode:
                 self._sensor_mode = sensor_mode
                 if self._sensor_mode == ZoneSensorMode.INTERNAL:

--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -99,7 +99,7 @@ class ZoneClimateMode(Enum):
 class ZoneTemperatureMode(Enum):
     COMPENSATION = 1  # driving the temp of water by comp curve (-5:5 deg C)
     DIRECT = 2  # driving the temp of water directly (20:55 deg C) 
-    ROOM = 3  # ROOM temperature is the driver, you set it directly from 10:35 deg C
+    ROOM = 3  # ROOM temperature is the driver, you set it directly from 10:30 deg C
     NAN = 4  # if external thermostat is choosen you cannot drive the temperature at all
 
 class HeishaMonZoneClimate(ClimateEntity):
@@ -152,8 +152,8 @@ class HeishaMonZoneClimate(ClimateEntity):
             self._attr_max_temp = 55
             self._attr_target_temperature_step = 1
         elif mode == ZoneTemperatureMode.ROOM:
-            self._attr_min_temp = 20
-            self._attr_max_temp = 55
+            self._attr_min_temp = 10
+            self._attr_max_temp = 30
             self._attr_target_temperature_step = 1
 #        else: # mode == ZoneTemperatureMode.NAN
             # TODO: disable widget as external thermostat is driving
@@ -165,13 +165,17 @@ class HeishaMonZoneClimate(ClimateEntity):
     async def async_set_temperature(self, **kwargs) -> None:
         temperature = kwargs.get("temperature")
 
-        if self._mode == ZoneClimateMode.COMPENSATION:
+        if self._mode == ZoneTemperatureMode.COMPENSATION:
             _LOGGER.info(
                 f"Changing {self.name} temperature offset to {temperature} for zone {self.zone_id}"
             )
-        elif self._mode == ZoneClimateMode.DIRECT:
+        elif self._mode == ZoneTemperatureMode.DIRECT:
             _LOGGER.info(
                 f"Changing {self.name} target temperature to {temperature} for zone {self.zone_id}"
+            )
+        elif self._mode == ZoneTemperatureMode.ROOM:
+            _LOGGER.info(
+                f"Changing {self.name} target room temperature to {temperature} for zone {self.zone_id}"
             )
         else:
             raise Exception(f"Unknown climate mode: {self._mode}")


### PR DESCRIPTION
Mode of operation is defined per zone based on Sensor Settings, not as currently implemented based on global Heating Mode.