### PR TITLE
🐛 Improve integration precision

### DIFF
--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntityDescription,
 )
-from homeassistant.components.integration.const import METHOD_TRAPEZOIDAL
+from homeassistant.components.integration.const import METHOD_LEFT
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.const import (
@@ -184,7 +184,7 @@ async def async_setup_entry(
     for sensor in sensors:
         if sensor.entity_description.native_unit_of_measurement == "W":
             integration_sensors.append(EnergyIntegrationEntity(
-                integration_method=METHOD_TRAPEZOIDAL,
+                integration_method=METHOD_LEFT,
                 name=f"{sensor.entity_description.name} Total",
                 round_digits=3,
                 source_entity=sensor.entity_id,


### PR DESCRIPTION
This is an attempt to improve situation for #168.

Before this patch, trapezoid method used to "hallucinate" energy usage: after a period of 1h at 0 W, a new value at 800W would be considered as 400Wh instead of 0.

After this patch, the same scenario should count 0Wh.

We still have an issue for cases when consumption/production does not change for a long time (and is different from 0) but it should not be a problem because heatpump usually vary in consumption/production quite often.