### PR TITLE
🐛 Compatibility with 2024.1

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -222,7 +222,7 @@ def first_positive(values) -> Optional[int]:
     return None
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HeishaMonEntityDescription:
     heishamon_topic_id: str | None = None
 
@@ -236,7 +236,7 @@ class HeishaMonEntityDescription:
     on_receive: Callable | None = None
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HeishaMonSensorEntityDescription(
     HeishaMonEntityDescription, SensorEntityDescription
 ):
@@ -245,7 +245,7 @@ class HeishaMonSensorEntityDescription(
     pass
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class MultiMQTTSensorEntityDescription(SensorEntityDescription):
     topics: list[str] | None = None
     # this callable will receive a list with as many entries as topics
@@ -260,7 +260,7 @@ class MultiMQTTSensorEntityDescription(SensorEntityDescription):
     heishamon_topic_id: Optional[str] = None
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HeishaMonSwitchEntityDescription(
     HeishaMonEntityDescription, SwitchEntityDescription
 ):
@@ -274,7 +274,7 @@ class HeishaMonSwitchEntityDescription(
     encoding: str = "utf-8"
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HeishaMonBinarySensorEntityDescription(
     HeishaMonEntityDescription, BinarySensorEntityDescription
 ):
@@ -283,7 +283,7 @@ class HeishaMonBinarySensorEntityDescription(
     pass
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HeishaMonSelectEntityDescription(
     HeishaMonEntityDescription, SelectEntityDescription
 ):
@@ -297,7 +297,7 @@ class HeishaMonSelectEntityDescription(
     state_to_mqtt: Optional[Callable] = None
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HeishaMonNumberEntityDescription(
     HeishaMonEntityDescription, NumberEntityDescription
 ):

--- a/custom_components/aquarea/update.py
+++ b/custom_components/aquarea/update.py
@@ -52,7 +52,7 @@ async def async_setup_entry(
     async_add_entities([HeishaMonMQTTUpdate(hass, firmware_update, config_entry)])
 
 
-@dataclass
+@dataclass(frozen=True, kw_only=True)
 class HeishaMonUpdateEntityDescription(
     HeishaMonEntityDescription, UpdateEntityDescription
 ):


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2023/12/11/entity-description-changes/ introduced a breaking change earlier than the announced 2025.1.

It happens for dataclass that don't simply inherit from EntityDescription but use a mixin pattern.
In this integration, we use the HeishaMonEntityDescription dataclass as a mixin to factorize common fields that are shared by all entities (mostly linked to the fact that all entities are linked to MQTT topics and need to process incoming messages).

Apparently many custom integration are affected by this.

Fix #171

Reference: https://developers.home-assistant.io/blog/2023/12/11/entity-description-changes/
Reference: https://github.com/home-assistant/core/issues/106617#issuecomment-1871979644
Reference: https://github.com/home-assistant/core/pull/105984