### PR TITLE
⬇ Restore compatibility with HA versions before 2024.1

### DIFF
--- a/custom_components/aquarea/update.py
+++ b/custom_components/aquarea/update.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import re
 import logging
 import json
-from dataclasses import dataclass
 import aiohttp
 from typing import Optional
 
@@ -22,7 +21,7 @@ from homeassistant.util import slugify
 
 from . import build_device_info
 from .const import DeviceType
-from .definitions import HeishaMonEntityDescription
+from .definitions import HeishaMonEntityDescription, frozendataclass
 
 _LOGGER = logging.getLogger(__name__)
 HEISHAMON_REPOSITORY = "Egyras/HeishaMon"
@@ -52,7 +51,7 @@ async def async_setup_entry(
     async_add_entities([HeishaMonMQTTUpdate(hass, firmware_update, config_entry)])
 
 
-@dataclass(frozen=True, kw_only=True)
+@frozendataclass
 class HeishaMonUpdateEntityDescription(
     HeishaMonEntityDescription, UpdateEntityDescription
 ):

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "HeishaMon",
   "render_readme": true,
-  "homeassistant": "2024.1"
+  "homeassistant": "2023.2"
 }


### PR DESCRIPTION
This patch introduces a backward compatible dataclass decorator that works whether core HA sets EntityDescription base dataclass as frozen or not.

This patch can be removed when we remove compatibility with HA 2023.x

This is a followup to PR #172

Fix #171