### PR TITLE
Expose all switch as binary sensor as well

### DIFF
--- a/custom_components/aquarea/number.py
+++ b/custom_components/aquarea/number.py
@@ -96,9 +96,6 @@ class HeishaMonMQTTNumber(NumberEntity):
         @callback
         def message_received(message):
             """Handle new MQTT messages."""
-            _LOGGER.debug(
-                f"Received message for {self.entity_description.name}: {message}"
-            )
             if self.entity_description.state is not None:
                 self._attr_native_value = self.entity_description.state(message.payload)
             else:

--- a/custom_components/aquarea/select.py
+++ b/custom_components/aquarea/select.py
@@ -83,9 +83,6 @@ class HeishaMonMQTTSelect(SelectEntity):
         @callback
         def message_received(message):
             """Handle new MQTT messages."""
-            _LOGGER.debug(
-                f"Received message for {self.entity_description.name}: {message}"
-            )
             if self.entity_description.state is not None:
                 self._attr_current_option = self.entity_description.state(
                     message.payload

--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -226,7 +226,6 @@ def extract_sum(values):
 
     for i, candidate in enumerate(chunks3(values)):
         if len(list(filter(lambda el: el is not None, candidate))) > 0:
-            _LOGGER.debug(f"Chunk {i} {candidate} has data")
             return sum(filter(lambda el: el is not None, candidate))
     _LOGGER.debug(f"No values at all, here the values: {values}, assuming sum is 0")
     return 0


### PR DESCRIPTION
Goal is to allow people to expose safely those entities as read-only in their dashboard.

Fix #151