### PR TITLE
🐛 Avoid early error in water heater

### DIFF
--- a/custom_components/aquarea/water_heater.py
+++ b/custom_components/aquarea/water_heater.py
@@ -112,10 +112,11 @@ class HeishaMonDHW(WaterHeaterEntity):
         await self.async_set_temperature(temperature=float(temp))
 
     def update_temperature_bounds(self) -> None:
-        self._attr_target_temperature_high = self._attr_target_temperature
-        self._attr_target_temperature_low = (
-            self._heat_delta + self._attr_target_temperature
-        )
+        if self._attr_target_temperature is not None:
+            self._attr_target_temperature_high = self._attr_target_temperature
+            self._attr_target_temperature_low = (
+                self._heat_delta + self._attr_target_temperature
+            )
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""


### PR DESCRIPTION
Before we received the first mqtt message about target temperature, any call to update_temperature_bounds leads to a failure.

It's better to not update the temperature bounds and wait for target_temperature_message.

Fix #234