### PR TITLE
Implement support for smart grid mode

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -355,6 +355,30 @@ def write_demandcontrol(value: int) -> str:
     return str(value / 100 * (234 - 43) + 43)
 
 
+def read_smart_grid_mode(value: str) -> Optional[int]:
+    if value == "0":
+        return "Normal"
+    elif value == "1":
+        return "Capacity 1"
+    elif value == "2":
+        return "HP/DHW off"
+    elif value == "3":
+        return "Capacity 2"
+    return value
+
+
+def write_smart_grid_mode(value: int) -> str:
+    if value == "Normal":
+        return 0
+    elif value == "Capacity 1":
+        return 1
+    elif value == "HP/DHW off":
+        return 2
+    elif value == "Capacity 2":
+        return 3
+    return int(value)
+
+
 def read_quiet_mode(value: str) -> str:
     # values range from 0 to 4
     if value == "4":
@@ -756,6 +780,17 @@ def build_selects(mqtt_prefix: str) -> list[HeishaMonSelectEntityDescription]:
             state_to_mqtt=external_pad_heater_type_to_mqtt,
             options=list(EXTERNAL_PAD_HEATER_TYPE.values()),
         ),
+        HeishaMonSelectEntityDescription(
+            heishamon_topic_id="SetSmartGridMode",
+            key=f"{mqtt_prefix}main/FakeSmartGridMode", # FIXME: find how to get real value
+            command_topic=f"{mqtt_prefix}commands/SetSmartGridMode",
+            name="Smart Grid Mode",
+            entity_category=EntityCategory.CONFIG,
+            state=read_smart_grid_mode,
+            state_to_mqtt=write_smart_grid_mode,
+            options=["Normal", "HP/DHW off", "Capacity 1", "Capacity 2"],
+            entity_registry_enabled_default=False,  # comes from the optional PCB: disabled by default
+        ),
     ]
 
 
@@ -893,7 +928,7 @@ def build_binary_sensors(
             heishamon_topic_id="TOP59",
             key=f"{mqtt_prefix}main/Room_Heater_State",
             name="Aquarea Room Heater Enabled",
-            state=bit_to_bool,            
+            state=bit_to_bool,
         ),
         HeishaMonBinarySensorEntityDescription(
             heishamon_topic_id="TOP60",
@@ -913,7 +948,7 @@ def build_binary_sensors(
             heishamon_topic_id="TOP68",
             key=f"{mqtt_prefix}main/Force_Heater_State",
             name="Aquarea Force heater status",
-            state=bit_to_bool,            
+            state=bit_to_bool,
         ),
         HeishaMonBinarySensorEntityDescription(
             heishamon_topic_id="TOP93",


### PR DESCRIPTION
With optional pcb emulation enabled, we can use smart grid mode of the heat pumps.

As this is the first time I did something with python for home assistant and only the second time I did something with python in general, I basically copied over some other entity and modified it until it worked.

The selected value is not retained in HA, only written to heishamon. So this is definitely an possible improvement to do in the future. Afaik there is no way to get the current value from heishamon (it's not even in its GUI, nor did I find something in its source code), so I guess we would have to save it in HA (or just a runtime only variable in this addon?) and hope that it's still up to date. As I don't know the best way to achieve this, I haven't bothered with it yet.

I verified this by logging it in the AQUAREA Service Cloud, where the value changes accordingly.

closes #237