### PR TITLE
Retain volatile optional pcb settings

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -647,8 +647,9 @@ def build_numbers(mqtt_prefix: str) -> list[HeishaMonNumberEntityDescription]:
         ),
         HeishaMonNumberEntityDescription(
             heishamon_topic_id="SetDemandControl",
-            key=f"{mqtt_prefix}main/FakeDemandControl",  # FIXME: find how to get real value
+            key=f"{mqtt_prefix}commands/SetDemandControl",
             command_topic=f"{mqtt_prefix}commands/SetDemandControl",
+            retain=True,
             name="Demand Control",
             entity_category=EntityCategory.CONFIG,
             native_unit_of_measurement="%",
@@ -782,8 +783,9 @@ def build_selects(mqtt_prefix: str) -> list[HeishaMonSelectEntityDescription]:
         ),
         HeishaMonSelectEntityDescription(
             heishamon_topic_id="SetSmartGridMode",
-            key=f"{mqtt_prefix}main/FakeSmartGridMode", # FIXME: find how to get real value
+            key=f"{mqtt_prefix}commands/SetSmartGridMode",
             command_topic=f"{mqtt_prefix}commands/SetSmartGridMode",
+            retain=True,
             name="Smart Grid Mode",
             entity_category=EntityCategory.CONFIG,
             state=read_smart_grid_mode,


### PR DESCRIPTION
The optional PCB commands `SetDemandControl` and `SetSmartGridMode` are neither written to any memory, nor are they published by heishamon to mqtt.

In order to retain the selected values in home assistant on page refresh and reboots and to reapply the values after an heishamon reset or reboot, I've set the mqtt flag `retain` to true of these commands and changed the subscribed mqtt topic to the actual command topics.

This way we have the mentioned benefits (keep values in HA, reapply values after heishamon reboot).
I couldn't think of any negative implications or reasons why we wouldn't want this behavior.

In contrast to regular (non-optional-pcb) commands like `SetQuietMode`, which are stored in the heat pump's memory, we shouldn't even have write cycles on the EEPROM as they are volatile.