### PR TITLE
🔭 Compatibility with HA 2025.1

### DIFF
--- a/custom_components/aquarea/water_heater.py
+++ b/custom_components/aquarea/water_heater.py
@@ -11,12 +11,19 @@ from homeassistant.components import mqtt
 from homeassistant.components.mqtt.client import async_publish
 
 from homeassistant.components.water_heater import (
-    WaterHeaterEntityEntityDescription,
     WaterHeaterEntity,
     WaterHeaterEntityFeature,
     STATE_ECO,
     STATE_PERFORMANCE,
 )
+try:
+    from homeassistant.components.water_heater import WaterHeaterEntityDescription
+except ImportError:
+    # compatibility code for HA < 2025.1
+    from homeassistant.components.water_heater import WaterHeaterEntityEntityDescription
+    WaterHeaterEntityDescription = WaterHeaterEntityEntityDescription
+
+
 
 from .definitions import OperatingMode
 from . import build_device_info
@@ -37,7 +44,7 @@ async def async_setup_entry(
         f"Starting bootstrap of water heater entities with prefix '{discovery_prefix}'"
     )
     """Set up HeishaMon water heater from config entry."""
-    description = WaterHeaterEntityEntityDescription(
+    description = WaterHeaterEntityDescription(
         key=f"{discovery_prefix}main/DHW_Target_Temp",
         name="Aquarea Domestic Water Heater",
     )
@@ -62,7 +69,7 @@ class HeishaMonDHW(WaterHeaterEntity):
     def __init__(
         self,
         hass: HomeAssistant,
-        description: WaterHeaterEntityEntityDescription,
+        description: WaterHeaterEntityDescription,
         config_entry: ConfigEntry,
     ) -> None:
         """Initialize the water heater entity."""


### PR DESCRIPTION
https://github.com/home-assistant/core/pull/132888 broke backward compatibility.
This patch will make this integration compatible with 2025.1 and still be backward compatible with earlier version.

Relates to https://github.com/home-assistant/core/issues/133216 and https://github.com/home-assistant/core/pull/132888

Reference: https://developers.home-assistant.io/blog/2024/12/13/water-heater-entity-description/