### PR TITLE
Add SwitchEntity to select internal or external sensor

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -934,6 +934,14 @@ def build_switches(mqtt_prefix: str) -> list[HeishaMonSwitchEntityDescription]:
             state=bit_to_bool,
         ),
         HeishaMonSwitchEntityDescription(
+            heishamon_topic_id="SET26",  # corresponds to "TOP108"
+            key=f"{mqtt_prefix}main/Alt_External_Sensor",
+            command_topic=f"{mqtt_prefix}commands/SetAltExternalSensor",
+            name="Aquarea use external outdoor sensor",
+            entity_category=EntityCategory.CONFIG,
+            state=bit_to_bool,
+        ),
+        HeishaMonSwitchEntityDescription(
             heishamon_topic_id="SET28",  # corresponds to TOP99
             key=f"{mqtt_prefix}main/Buffer_Installed",
             command_topic=f"{mqtt_prefix}commands/SetBuffer",

--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -1091,12 +1091,6 @@ def build_binary_sensors(
             state=bit_to_bool,
         ),
         HeishaMonBinarySensorEntityDescription(
-            heishamon_topic_id="TOP108",
-            key=f"{mqtt_prefix}main/Alt_External_Sensor",
-            name="Aquarea external outdoor sensor selected",
-            state=bit_to_bool,
-        ),
-        HeishaMonBinarySensorEntityDescription(
             heishamon_topic_id="TOP109",
             key=f"{mqtt_prefix}main/Anti_Freeze_Mode",
             name="Aquarea anti freeze mode",


### PR DESCRIPTION
Currently, the use of an external temperature sensor is only indicated by a binary_sensor. This small pull request adds the ability to specify the use of the external sensor via a switch.