### PR TITLE
Increase maximum heating temperature

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -744,7 +744,7 @@ def build_numbers(mqtt_prefix: str) -> list[HeishaMonNumberEntityDescription]:
     ranges = {
         "Heat": {
             "Outside": [-20, 30],
-            "Target": [15, 60],
+            "Target": [15, 70],
         },
         "Cool": {
             "Outside": [15, 30],


### PR DESCRIPTION
Apparently some heatpump using R290 (propane) as heat transfer fluid can go up to 70°C.

Fix #298