### PR TITLE
Add target temperature step to water heater entity

### DIFF
--- a/custom_components/aquarea/water_heater.py
+++ b/custom_components/aquarea/water_heater.py
@@ -94,6 +94,7 @@ class HeishaMonDHW(WaterHeaterEntity):
         self._attr_current_operation = STATE_ECO
         self._attr_min_temp = 40
         self._attr_max_temp = 65
+        self._attr_target_temperature_step = 1
         self._attr_precision = 1
         self._attr_operation_list = [STATE_OFF, STATE_SUPERECO, STATE_ECO, STATE_PERFORMANCE]
         self._heat_delta = 0


### PR DESCRIPTION
By default, the water heater entity uses a target temperature step of 0.5 °C. For the Panasonic heat pump model WH-SXC09H3E8 9 3ph T-CAP which I tested, the target temperature step is 1.0 °C. If there are Panasonic heat pumps that actually support setting the target temperature with a 0.5 °C step, it would probably make sense to differentiate the step size based on the specific heat pump model.