### PR TITLE
Handle turnoff DHW in all situations

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -78,7 +78,13 @@ class OperatingMode(Flag):
         }
 
     def __int__(self) -> int:
-        return self.modes_to_int()[self]
+        mode_mapping = self.modes_to_int()
+        if self not in mode_mapping:
+            raise ValueError(
+                f"Invalid operating mode {self} (value: {self.value}). "
+                f"Cannot convert to MQTT value. This may indicate an empty/uninitialized mode."
+            )
+        return mode_mapping[self]
 
     @staticmethod
     def from_str(str_repr: str) -> OperatingMode:


### PR DESCRIPTION
Before this patch, if the heatpump was in DHW only mode, switching off the DHW was failing (because it requires to power off the pump instead of turning off DHW).
This is due to not having a mode to represent heat/cool off + dhw off using the "operating mode" model.

Fix #333