### PR TITLE
🐛 Correct retry logic for compensation curve entities

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -829,6 +829,7 @@ def build_numbers(mqtt_prefix: str) -> list[HeishaMonNumberEntityDescription]:
                             native_unit_of_measurement="°C",
                             # by default we hide all options related to less common setup (cooling, buffer, solar and pool)
                             entity_registry_enabled_default=(action == "Heat"),
+                            state=float,
                             state_to_mqtt=write_curves_gen(zone_id, action, loc, point),
                         )
                     )


### PR DESCRIPTION
Compensation curb entities had an inconsistent state parsing (received strings via mqtt but sending float). Home Assistant logic was catching that for us but the retry logic could not compare expected and received value and thus triggered retries.

Fix #359