### PR TITLE
Proper handle of Heatpump_State for climate and water_heater

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -157,6 +157,7 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
 
         self._zone_state = ZoneState(0)  # i.e None
         self._operating_mode = OperatingMode(0)  # i.e None
+        self._heatpump_state: bool | None = None
 
         self._sensor_mode = ZoneSensorMode.WATER
         self._climate_mode = ZoneClimateMode.DIRECT
@@ -397,6 +398,8 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
         )
 
         def guess_hvac_mode() -> HVACMode:
+            if self._heatpump_state is False:
+                return HVACMode.OFF
             if self.heater:
                 global_heating = OperatingMode.HEAT in self._operating_mode
                 zone_heating = ZoneState.from_id(self.zone_id) in self._zone_state
@@ -438,13 +441,53 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
             1,
         )
 
+        @callback
+        def heatpump_state_message_received(message):
+            self._heatpump_state = message.payload == "1"
+            self._attr_hvac_mode = guess_hvac_mode()
+            self.verify_command_confirmation(self._attr_hvac_mode)
+            self.async_write_ha_state()
+
+        await mqtt.async_subscribe(
+            self.hass,
+            f"{self.discovery_prefix}main/Heatpump_State",
+            heatpump_state_message_received,
+            1,
+        )
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        system_is_off = self._operating_mode == OperatingMode(0) or self._heatpump_state is False
+
         if hvac_mode == HVACMode.HEAT:
-            new_zone_state = self._zone_state | ZoneState.from_id(self.zone_id)
-            new_operating_mode = self._operating_mode | OperatingMode.HEAT
+            if system_is_off:
+                await async_publish(
+                    self.hass,
+                    f"{self.discovery_prefix}commands/SetHeatpump",
+                    "1",
+                    0,
+                    False,
+                    "utf-8",
+                )
+                new_zone_state = ZoneState.from_id(self.zone_id)
+                new_operating_mode = OperatingMode.HEAT
+            else:
+                new_zone_state = self._zone_state | ZoneState.from_id(self.zone_id)
+                new_operating_mode = self._operating_mode | OperatingMode.HEAT
         elif hvac_mode == HVACMode.COOL:
-            new_zone_state = self._zone_state | ZoneState.from_id(self.zone_id)
-            new_operating_mode = self._operating_mode | OperatingMode.COOL
+            if system_is_off:
+                await async_publish(
+                    self.hass,
+                    f"{self.discovery_prefix}commands/SetHeatpump",
+                    "1",
+                    0,
+                    False,
+                    "utf-8",
+                )
+                new_zone_state = ZoneState.from_id(self.zone_id)
+                new_operating_mode = OperatingMode.COOL
+            else:
+                new_zone_state = self._zone_state | ZoneState.from_id(self.zone_id)
+                new_operating_mode = self._operating_mode | OperatingMode.COOL
         elif hvac_mode == HVACMode.OFF:
             new_zone_state = self._zone_state & ~ZoneState.from_id(self.zone_id)
             new_operating_mode = self._operating_mode
@@ -454,10 +497,22 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
                 else:
                     new_operating_mode = self._operating_mode & ~OperatingMode.COOL
         else:
-            raise NotImplemented(
+            raise NotImplementedError(
                 f"Mode {hvac_mode} has not been implemented by this entity"
             )
-        if new_operating_mode != self._operating_mode:
+        if new_operating_mode == OperatingMode(0):
+            _LOGGER.debug(
+                f"{self._climate_type()} Turning off main heatpump power after disabling last active mode"
+            )
+            await async_publish(
+                self.hass,
+                f"{self.discovery_prefix}commands/SetHeatpump",
+                "0",
+                0,
+                False,
+                "utf-8",
+            )
+        elif new_operating_mode != self._operating_mode:
             _LOGGER.debug(
                 f"{self._climate_type()} Setting operation mode {new_operating_mode} for zone {self.zone_id}"
             )
@@ -481,6 +536,11 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
                 False,
                 "utf-8",
             )
+        self._operating_mode = new_operating_mode
+        if new_operating_mode == OperatingMode(0):
+            self._heatpump_state = False
+        elif system_is_off:
+            self._heatpump_state = True
         self._attr_hvac_mode = hvac_mode  # let's be optimistic
         self.async_write_ha_state()
 

--- a/custom_components/aquarea/water_heater.py
+++ b/custom_components/aquarea/water_heater.py
@@ -102,6 +102,7 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
         self._desired_current_operation = STATE_OFF
         self._heat_delta = 0
         self._operating_mode = OperatingMode(0)  # Initialize to empty mode until MQTT updates arrive
+        self._heatpump_state: bool | None = None
 
     async def async_set_temperature(self, **kwargs) -> None:
         temperature = kwargs.get("temperature")
@@ -216,7 +217,10 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
             dhw_is_on = bool(self._operating_mode & OperatingMode.DHW)
             self.verify_command_confirmation(dhw_is_on)
 
-            if not (self._operating_mode & OperatingMode.DHW):
+            if self._heatpump_state is False:
+                _LOGGER.debug("Heatpump main power is off, forcing DHW to off")
+                self._attr_current_operation = STATE_OFF
+            elif not (self._operating_mode & OperatingMode.DHW):
                 _LOGGER.debug("DHW is off")
                 self._attr_current_operation = STATE_OFF
             elif self._attr_current_operation == STATE_OFF: # DHW is on but it was off before
@@ -230,10 +234,27 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
             1,
         )
 
+        @callback
+        def heatpump_state_received(message):
+            self._heatpump_state = message.payload == "1"
+            if self._heatpump_state is False:
+                self.verify_command_confirmation(False)
+                self._attr_current_operation = STATE_OFF
+            self.async_write_ha_state()
+
+        await mqtt.async_subscribe(
+            self.hass,
+            f"{self.discovery_prefix}main/Heatpump_State",
+            heatpump_state_received,
+            1,
+        )
+
     async def async_turn_on(self, **kwargs: Any) -> None:
-        # If operating mode is 0 (system is off), turn on main power first
-        if self._operating_mode == OperatingMode(0):
-            _LOGGER.debug("Operating mode is 0, turning on main power first")
+        system_is_off = self._operating_mode == OperatingMode(0) or self._heatpump_state is False
+
+        # If system appears off, turn on main power first
+        if system_is_off:
+            _LOGGER.debug("System appears off, turning on main power first")
             await async_publish(
                 self.hass,
                 f"{self.discovery_prefix}commands/SetHeatpump",
@@ -243,7 +264,11 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
                 "utf-8",
             )
 
-        new_operating_mode = self._operating_mode | OperatingMode.DHW
+        # When system is off, force only requested mode (no derivation from stale state).
+        if system_is_off:
+            new_operating_mode = OperatingMode.DHW
+        else:
+            new_operating_mode = self._operating_mode | OperatingMode.DHW
         _LOGGER.debug(f"setting operating mode {new_operating_mode}")
         await async_publish(
                 self.hass,
@@ -255,6 +280,8 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
         )
         # Optimistically update operating mode
         self._operating_mode = new_operating_mode
+        if system_is_off:
+            self._heatpump_state = True
 
         # Register command for retry - expect DHW to be on (True)
         await self.register_command(
@@ -278,6 +305,7 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
             )
             # Optimistically update operating mode
             self._operating_mode = OperatingMode(0)
+            self._heatpump_state = False
         else:
             # Normal case: just remove DHW from the mode
             _LOGGER.debug(f"setting operating mode {new_operating_mode}")


### PR DESCRIPTION
Fix #347

Changes:
* Added explicit tracking of main heat pump power state (_heatpump_state) in both climate.py and water_heater.py.
* Subscribed both entities to MQTT topic main/Heatpump_State to keep UI state aligned with real device power status.
* Updated climate HVAC mode inference to report OFF immediately when the main heat pump is powered off.
* Improved async_set_hvac_mode logic to power on the heat pump before enabling HEAT/COOL when the system is off.
* Added logic to power off the main heat pump when disabling the last active operating mode.
* Fixed exception type in climate mode handling from NotImplemented to NotImplementedError.
* Updated DHW operation handling to force OFF when main power is off, even if stale operating mode flags remain.
* Refined DHW turn on/off flows to avoid deriving new modes from stale state and to optimistically sync _operating_mode/_heatpump_state.