### PR TITLE
Add DHW Sensor Selection entity (TOP143)

### DIFF
--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -2210,15 +2210,6 @@ def build_sensors(mqtt_prefix: str) -> list[HeishaMonSensorEntityDescription]:
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         HeishaMonSensorEntityDescription(
-            heishamon_topic_id="TOP143",
-            key=f"{mqtt_prefix}main/DHW_Sensor_Selection",
-            name="Aquarea DHW Sensor Selection",
-            state=read_dhw_sensor_selection,
-            device_class=SensorDeviceClass.ENUM,
-            options=list(DHW_SENSOR_SELECTION.values()),
-            entity_registry_enabled_default=False,  # deprecated, use SET43 select entity instead
-        ),
-        HeishaMonSensorEntityDescription(
             heishamon_topic_id="STAT1_rssi",
             key=f"{mqtt_prefix}stats",
             name="HeishaMon RSSI",

--- a/custom_components/aquarea/definitions.py
+++ b/custom_components/aquarea/definitions.py
@@ -964,6 +964,18 @@ def build_selects(mqtt_prefix: str) -> list[HeishaMonSelectEntityDescription]:
             options=list(SMART_GRID_MODES_STRING.values()),
             entity_registry_enabled_default=False,  # comes from the optional PCB: disabled by default
         ),
+        HeishaMonSelectEntityDescription(
+            heishamon_topic_id="SET43",  # corresponds to TOP143
+            key=f"{mqtt_prefix}main/DHW_Sensor_Selection",
+            command_topic=f"{mqtt_prefix}main/SetDHWSensorSelection",
+            name="Aquarea DHW Sensor Selection",
+            entity_category=EntityCategory.CONFIG,
+            icon="mdi:thermometer-water",
+            state=read_dhw_sensor_selection,
+            state_to_mqtt=dhw_sensor_selection_to_mqtt,
+            options=list(DHW_SENSOR_SELECTION.values()),
+            entity_registry_enabled_default=False,  # only applicable to K/L series All-In-One units
+        ),
     ]
 
 
@@ -1368,6 +1380,20 @@ def read_quiet_mode_priority(value: str) -> Optional[str]:
 
 def quiet_mode_priority_to_mqtt(value: str) -> Optional[str]:
     return lookup_by_value(QUIET_MODE_PRIORITY, value)
+
+
+DHW_SENSOR_SELECTION = {
+    "0": "Top",
+    "1": "Center",
+}
+
+
+def read_dhw_sensor_selection(value: str) -> Optional[str]:
+    return DHW_SENSOR_SELECTION.get(value, None)
+
+
+def dhw_sensor_selection_to_mqtt(value: str) -> Optional[str]:
+    return lookup_by_value(DHW_SENSOR_SELECTION, value)
 
 
 def read_temp(value: str) -> Optional[Any]:
@@ -2182,6 +2208,15 @@ def build_sensors(mqtt_prefix: str) -> list[HeishaMonSensorEntityDescription]:
             state=int,
             suggested_display_precision=0,
             entity_category=EntityCategory.DIAGNOSTIC,
+        ),
+        HeishaMonSensorEntityDescription(
+            heishamon_topic_id="TOP143",
+            key=f"{mqtt_prefix}main/DHW_Sensor_Selection",
+            name="Aquarea DHW Sensor Selection",
+            state=read_dhw_sensor_selection,
+            device_class=SensorDeviceClass.ENUM,
+            options=list(DHW_SENSOR_SELECTION.values()),
+            entity_registry_enabled_default=False,  # deprecated, use SET43 select entity instead
         ),
         HeishaMonSensorEntityDescription(
             heishamon_topic_id="STAT1_rssi",


### PR DESCRIPTION
## Summary

Add support for the new HeishaMon `DHW_Sensor_Selection` topic (TOP143), introduced in [HeishaMon v4.1.2](https://github.com/Egykan/HeishaMon/pull/847).

This applies to **K/L series All-In-One units** with dual temperature sensors in the DHW tank, allowing selection between the Top and Center sensor for DHW temperature measurement.

### Changes

- **New select entity** (`SET43` / `TOP143`):
  - State topic: `panasonic_heat_pump/main/DHW_Sensor_Selection`
  - Command topic: `panasonic_heat_pump/main/SetDHWSensorSelection`
  - Options: `Top` (MQTT value `0`), `Center` (MQTT value `1`)
  - Icon: `mdi:thermometer-water`
  - Disabled by default (only applicable to specific unit types)

- **New sensor entity** (`TOP143`): Read-only deprecated sensor, consistent with the pattern used for other configurable settings (TOP139-TOP141 each have both a select and a deprecated sensor).

### Implementation

Follows the exact same patterns as existing select entities (HEATING_CONTROL/SET39, SMART_DHW/SET40, QUIET_MODE_PRIORITY/SET41, etc.):
- Dictionary mapping MQTT values to human-readable options
- `read_dhw_sensor_selection()` / `dhw_sensor_selection_to_mqtt()` conversion functions
- `HeishaMonSelectEntityDescription` with `EntityCategory.CONFIG`

## References

- HeishaMon firmware PR: https://github.com/Egykan/HeishaMon/pull/847

## Test plan

- [ ] Verify entity appears (when enabled) on a K/L series All-In-One unit
- [ ] Verify reading current DHW sensor selection via MQTT state topic
- [ ] Verify changing selection via the select entity publishes correct MQTT value
- [ ] Verify entity does not interfere on units without dual DHW sensors