### PR TITLE
fix(climate,water_heater): make heatpump power ON/OFF transitions reliable and state-driven

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -1,5 +1,6 @@
 """Support for HeishaMon controlled heatpumps through MQTT."""
 from __future__ import annotations
+import asyncio
 import logging
 from dataclasses import dataclass
 from enum import Enum, Flag, auto
@@ -211,6 +212,31 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
         else:
             return "[COOL]"
 
+    async def _set_heatpump_state(self, should_be_on: bool) -> None:
+        payload = "1" if should_be_on else "0"
+        expected_state = should_be_on
+        for attempt in range(1, 4):
+            _LOGGER.debug(
+                f"{self._climate_type()} Sending heatpump {'ON' if should_be_on else 'OFF'} command (attempt {attempt}/3)"
+            )
+            await async_publish(
+                self.hass,
+                f"{self.discovery_prefix}commands/SetHeatpump",
+                payload,
+                0,
+                False,
+                "utf-8",
+            )
+            await asyncio.sleep(1.0)
+            if self._heatpump_state is expected_state:
+                _LOGGER.debug(
+                    f"{self._climate_type()} Heatpump {'ON' if should_be_on else 'OFF'} confirmed by MQTT state (attempt {attempt}/3)"
+                )
+                return
+        _LOGGER.warning(
+            f"{self._climate_type()} Heatpump {'ON' if should_be_on else 'OFF'} not confirmed after 3 attempts"
+        )
+
     def change_mode(self, mode: ZoneTemperatureMode, initialization: bool = False):
         if self._mode == mode:
             _LOGGER.debug(f"{self._climate_type()} Enforcing mode to {mode} for zone {self.zone_id}")
@@ -398,7 +424,7 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
         )
 
         def guess_hvac_mode() -> HVACMode:
-            if self._heatpump_state is False:
+            if self._heatpump_state is not True:
                 return HVACMode.OFF
             if self.heater:
                 global_heating = OperatingMode.HEAT in self._operating_mode
@@ -443,7 +469,19 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
 
         @callback
         def heatpump_state_message_received(message):
+            previous_heatpump_state = self._heatpump_state
             self._heatpump_state = message.payload == "1"
+            if self._heatpump_state != previous_heatpump_state:
+                _LOGGER.debug(
+                    f"{self._climate_type()} Heatpump state changed via MQTT from "
+                    f"{'ON' if previous_heatpump_state else 'OFF' if previous_heatpump_state is not None else 'UNKNOWN'} "
+                    f"to {'ON' if self._heatpump_state else 'OFF'}"
+                )
+            else:
+                _LOGGER.debug(
+                    f"{self._climate_type()} Heatpump state received via MQTT unchanged: "
+                    f"{'ON' if self._heatpump_state else 'OFF'}"
+                )
             self._attr_hvac_mode = guess_hvac_mode()
             self.verify_command_confirmation(self._attr_hvac_mode)
             self.async_write_ha_state()
@@ -456,18 +494,25 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
         )
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        _LOGGER.debug(f"{self._climate_type()} Requested HVAC mode change to {hvac_mode} for zone {self.zone_id}")
+        if hvac_mode == self._attr_hvac_mode:
+            _LOGGER.debug(
+                f"{self._climate_type()} HVAC mode for zone {self.zone_id} is already {hvac_mode}, nothing to do"
+            )
+            self.verify_command_confirmation(hvac_mode)
+            return
+
+        # Register command before sending MQTT commands to avoid missing fast confirmations.
+        await self.register_command(
+            expected_value=hvac_mode,
+            retry_callback=lambda: self.async_set_hvac_mode(hvac_mode),
+        )
+
         system_is_off = self._operating_mode == OperatingMode(0) or self._heatpump_state is False
 
         if hvac_mode == HVACMode.HEAT:
             if system_is_off:
-                await async_publish(
-                    self.hass,
-                    f"{self.discovery_prefix}commands/SetHeatpump",
-                    "1",
-                    0,
-                    False,
-                    "utf-8",
-                )
+                await self._set_heatpump_state(True)
                 new_zone_state = ZoneState.from_id(self.zone_id)
                 new_operating_mode = OperatingMode.HEAT
             else:
@@ -475,14 +520,7 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
                 new_operating_mode = self._operating_mode | OperatingMode.HEAT
         elif hvac_mode == HVACMode.COOL:
             if system_is_off:
-                await async_publish(
-                    self.hass,
-                    f"{self.discovery_prefix}commands/SetHeatpump",
-                    "1",
-                    0,
-                    False,
-                    "utf-8",
-                )
+                await self._set_heatpump_state(True)
                 new_zone_state = ZoneState.from_id(self.zone_id)
                 new_operating_mode = OperatingMode.COOL
             else:
@@ -501,17 +539,8 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
                 f"Mode {hvac_mode} has not been implemented by this entity"
             )
         if new_operating_mode == OperatingMode(0):
-            _LOGGER.debug(
-                f"{self._climate_type()} Turning off main heatpump power after disabling last active mode"
-            )
-            await async_publish(
-                self.hass,
-                f"{self.discovery_prefix}commands/SetHeatpump",
-                "0",
-                0,
-                False,
-                "utf-8",
-            )
+            _LOGGER.debug(f"{self._climate_type()} Turning off main heatpump power after disabling last active mode")
+            await self._set_heatpump_state(False)
         elif new_operating_mode != self._operating_mode:
             _LOGGER.debug(
                 f"{self._climate_type()} Setting operation mode {new_operating_mode} for zone {self.zone_id}"
@@ -539,16 +568,8 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
         self._operating_mode = new_operating_mode
         if new_operating_mode == OperatingMode(0):
             self._heatpump_state = False
-        elif system_is_off:
-            self._heatpump_state = True
         self._attr_hvac_mode = hvac_mode  # let's be optimistic
         self.async_write_ha_state()
-
-        # Register command for retry if not confirmed
-        await self.register_command(
-            expected_value=hvac_mode,
-            retry_callback=lambda: self.async_set_hvac_mode(hvac_mode),
-        )
 
     @property
     def device_info(self):

--- a/custom_components/aquarea/water_heater.py
+++ b/custom_components/aquarea/water_heater.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import asyncio
 import logging
 
 from typing import Any
@@ -104,6 +105,31 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
         self._operating_mode = OperatingMode(0)  # Initialize to empty mode until MQTT updates arrive
         self._heatpump_state: bool | None = None
 
+    async def _set_heatpump_state(self, should_be_on: bool) -> None:
+        payload = "1" if should_be_on else "0"
+        expected_state = should_be_on
+        for attempt in range(1, 4):
+            _LOGGER.debug(
+                f"[DHW] Sending heatpump {'ON' if should_be_on else 'OFF'} command (attempt {attempt}/3)"
+            )
+            await async_publish(
+                self.hass,
+                f"{self.discovery_prefix}commands/SetHeatpump",
+                payload,
+                0,
+                False,
+                "utf-8",
+            )
+            await asyncio.sleep(1.0)
+            if self._heatpump_state is expected_state:
+                _LOGGER.debug(
+                    f"[DHW] Heatpump {'ON' if should_be_on else 'OFF'} confirmed by MQTT state (attempt {attempt}/3)"
+                )
+                return
+        _LOGGER.warning(
+            f"[DHW] Heatpump {'ON' if should_be_on else 'OFF'} not confirmed after 3 attempts"
+        )
+
     async def async_set_temperature(self, **kwargs) -> None:
         temperature = kwargs.get("temperature")
         _LOGGER.debug(f"Changing {self.name} target temperature to {temperature})")
@@ -126,13 +152,14 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
         )
 
     async def async_set_operation_mode(self, operation_mode: str):
+        _LOGGER.debug(f"[DHW] Requested operation mode change to {operation_mode}")
         if operation_mode == STATE_OFF:
             await self.async_turn_off()
             # optimistic update
             self._attr_current_operation = STATE_OFF
             self.async_write_ha_state()
             return
-        if not (self._operating_mode & OperatingMode.DHW):
+        if self._heatpump_state is False or not (self._operating_mode & OperatingMode.DHW):
             await self.async_turn_on()
         # optimistic update
         self._attr_current_operation = operation_mode
@@ -211,7 +238,14 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
 
         @callback
         def operating_mode_received(message):
+            previous_operating_mode = self._operating_mode
             self._operating_mode = OperatingMode.from_mqtt(message.payload)
+            if self._operating_mode != previous_operating_mode:
+                _LOGGER.debug(
+                    f"[DHW] Operating mode changed via MQTT from {previous_operating_mode} to {self._operating_mode}"
+                )
+            else:
+                _LOGGER.debug(f"[DHW] Operating mode received via MQTT unchanged: {self._operating_mode}")
 
             # Verify if this confirms a pending command (for turn_on/turn_off)
             dhw_is_on = bool(self._operating_mode & OperatingMode.DHW)
@@ -236,7 +270,16 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
 
         @callback
         def heatpump_state_received(message):
+            previous_heatpump_state = self._heatpump_state
             self._heatpump_state = message.payload == "1"
+            if self._heatpump_state != previous_heatpump_state:
+                _LOGGER.debug(
+                    f"[DHW] Heatpump state changed via MQTT from "
+                    f"{'ON' if previous_heatpump_state else 'OFF' if previous_heatpump_state is not None else 'UNKNOWN'} "
+                    f"to {'ON' if self._heatpump_state else 'OFF'}"
+                )
+            else:
+                _LOGGER.debug(f"[DHW] Heatpump state received via MQTT unchanged: {'ON' if self._heatpump_state else 'OFF'}")
             if self._heatpump_state is False:
                 self.verify_command_confirmation(False)
                 self._attr_current_operation = STATE_OFF
@@ -250,26 +293,32 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
         )
 
     async def async_turn_on(self, **kwargs: Any) -> None:
+        _LOGGER.debug("[DHW] Turn ON requested")
+        dhw_is_on = bool(self._operating_mode & OperatingMode.DHW)
+        if dhw_is_on and self._heatpump_state is not False:
+            _LOGGER.debug("[DHW] DHW is already ON, nothing to do")
+            self.verify_command_confirmation(True)
+            return
+
+        # Register command before sending MQTT commands to avoid missing fast confirmations.
+        await self.register_command(
+            expected_value=True,
+            retry_callback=lambda: self.async_turn_on(),
+        )
+
         system_is_off = self._operating_mode == OperatingMode(0) or self._heatpump_state is False
 
         # If system appears off, turn on main power first
         if system_is_off:
-            _LOGGER.debug("System appears off, turning on main power first")
-            await async_publish(
-                self.hass,
-                f"{self.discovery_prefix}commands/SetHeatpump",
-                "1",
-                0,
-                False,
-                "utf-8",
-            )
+            _LOGGER.debug("[DHW] System appears off, turning on main power first")
+            await self._set_heatpump_state(True)
 
         # When system is off, force only requested mode (no derivation from stale state).
         if system_is_off:
             new_operating_mode = OperatingMode.DHW
         else:
             new_operating_mode = self._operating_mode | OperatingMode.DHW
-        _LOGGER.debug(f"setting operating mode {new_operating_mode}")
+        _LOGGER.debug(f"[DHW] Setting operating mode to {new_operating_mode}")
         await async_publish(
                 self.hass,
                 f"{self.discovery_prefix}commands/SetOperationMode",
@@ -280,35 +329,34 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
         )
         # Optimistically update operating mode
         self._operating_mode = new_operating_mode
-        if system_is_off:
-            self._heatpump_state = True
 
-        # Register command for retry - expect DHW to be on (True)
-        await self.register_command(
-            expected_value=True,
-            retry_callback=lambda: self.async_turn_on(),
-        )
     async def async_turn_off(self, **kwargs: Any) -> None:
+        _LOGGER.debug("[DHW] Turn OFF requested")
+        dhw_is_on = bool(self._operating_mode & OperatingMode.DHW)
+        if not dhw_is_on or self._heatpump_state is False:
+            _LOGGER.debug("[DHW] DHW is already OFF, nothing to do")
+            self.verify_command_confirmation(False)
+            return
+
+        # Register command before sending MQTT commands to avoid missing fast confirmations.
+        await self.register_command(
+            expected_value=False,
+            retry_callback=lambda: self.async_turn_off(),
+        )
+
         new_operating_mode = self._operating_mode & ~OperatingMode.DHW
 
         # Check if removing DHW leaves no valid mode (this happens when current mode is "DHW only")
         if new_operating_mode == OperatingMode(0):
             # Turn off the entire system via main power switch
-            _LOGGER.debug("Turning off DHW would leave no valid mode, turning off main power instead")
-            await async_publish(
-                self.hass,
-                f"{self.discovery_prefix}commands/SetHeatpump",
-                "0",
-                0,
-                False,
-                "utf-8",
-            )
+            _LOGGER.debug("[DHW] Turning off DHW would leave no valid mode, turning off main power")
+            await self._set_heatpump_state(False)
             # Optimistically update operating mode
             self._operating_mode = OperatingMode(0)
             self._heatpump_state = False
         else:
             # Normal case: just remove DHW from the mode
-            _LOGGER.debug(f"setting operating mode {new_operating_mode}")
+            _LOGGER.debug(f"[DHW] Setting operating mode to {new_operating_mode}")
             await async_publish(
                 self.hass,
                 f"{self.discovery_prefix}commands/SetOperationMode",
@@ -319,12 +367,6 @@ class HeishaMonDHW(CommandRetryMixin, WaterHeaterEntity):
             )
             # Optimistically update operating mode
             self._operating_mode = new_operating_mode
-
-        # Register command for retry - expect DHW to be off (False)
-        await self.register_command(
-            expected_value=False,
-            retry_callback=lambda: self.async_turn_off(),
-        )
 
     @property
     def device_info(self):


### PR DESCRIPTION
## Summary

  This PR fixes unreliable ON/OFF behavior in climate and water_heater when the main heat pump power is OFF.

  In some scenarios, turning ON climate/DHW changed entity state in Home Assistant, but the physical heat pump stayed OFF.
  It also improves state/log consistency by distinguishing real MQTT state transitions from unchanged status updates.

  Closes #379.

  ## Problem

  When the system was OFF (Heatpump_State=0), turn_on paths were not always ensuring a confirmed SetHeatpump=1 transition before proceeding with mode changes.

  As a result:

  - climate / water_heater could appear ON in HA,
  - while the real heat pump remained OFF.

  ## Root Cause

  Power state changes (SetHeatpump) were effectively one-shot in ON/OFF critical paths.
  If confirmation timing or message delivery was unfavorable, power transition was not always reliably enforced before/alongside operation mode updates.

  ## What Changed

  ### custom_components/aquarea/climate.py

  - Added _set_heatpump_state(should_be_on) helper:
      - publishes commands/SetHeatpump,
      - retries up to 3 times,
      - waits for MQTT Heatpump_State confirmation between attempts.
  - async_set_hvac_mode(...) now uses _set_heatpump_state(True) when system is OFF.
  - Uses _set_heatpump_state(False) when disabling the last active mode.
  - Removed optimistic local self._heatpump_state = True assignment before MQTT confirmation.
  - Improved heat pump state callback logging:
      - logs real transitions (from X to Y) vs unchanged updates.

  ### custom_components/aquarea/water_heater.py

  - Added _set_heatpump_state(should_be_on) helper with same retry/confirmation logic.
  - async_turn_on(...) path now powers ON pump reliably when system is OFF.
  - async_turn_off(...) path uses helper when DHW OFF implies full power OFF.
  - Removed optimistic local ON assumptions before MQTT confirmation.
  - Improved callback logging:
      - operating_mode_received(...) and heatpump_state_received(...)
        now differentiate changed vs unchanged MQTT updates.

  ## Behavior After Fix

  - ON transitions from OFF state are now reliable and confirmed by MQTT.
  - OFF transitions of the last active mode are handled consistently.
  - Logs better represent real state transitions and reduce ambiguity during diagnostics.

  ## Validation

  Manually tested repeated sequences for:

  - OFF -> DHW ON -> DHW OFF
  - OFF -> HEAT ON -> HEAT OFF
  - mixed DHW + HEAT enable/disable order

  Observed stable pump power transitions with MQTT confirmations.

  ## Risk / Compatibility

  - Scope limited to climate.py and water_heater.py.
  - No API/schema changes.
  - Retry count is bounded (3 attempts), only for SetHeatpump helper in critical paths.

