### PR TITLE
Fix EnergyIntegrationEntity construction for HA 2026.8 (IntegrationSensor dropped `hass` again)

### DIFF
--- a/custom_components/aquarea/sensor.py
+++ b/custom_components/aquarea/sensor.py
@@ -1,12 +1,12 @@
 """Support for HeishaMon controlled heatpumps through MQTT."""
 from __future__ import annotations
+import inspect
 import logging
 from typing import Any, Optional
 from dataclasses import dataclass
 from collections.abc import Callable
 from datetime import timedelta
 
-from awesomeversion import AwesomeVersion
 from homeassistant.components import mqtt
 from homeassistant.components.sensor import (
     SensorEntity,
@@ -17,10 +17,7 @@ from homeassistant.components.sensor import (
 from homeassistant.components.integration.const import METHOD_LEFT
 from homeassistant.components.integration.sensor import IntegrationSensor
 from homeassistant.helpers.entity import EntityCategory
-from homeassistant.const import (
-    UnitOfTime,
-    __version__ as HA_VERSION,
-)
+from homeassistant.const import UnitOfTime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -234,10 +231,13 @@ def extract_sum(values):
 class EnergyIntegrationEntity(IntegrationSensor):
 
     def __init__(self, hass, **kwargs):
-        if AwesomeVersion(HA_VERSION) < AwesomeVersion("2025.8"):
-            super().__init__(**kwargs)
-        else:
-            super().__init__(hass, **kwargs)
+        # HA core removed the `hass` constructor argument from IntegrationSensor
+        # in 2026.8 (home-assistant/core#177596). Inspect the installed
+        # signature instead of comparing HA_VERSION so this keeps working both
+        # before and after that change, regardless of which side we're on.
+        if "hass" in inspect.signature(IntegrationSensor.__init__).parameters:
+            kwargs["hass"] = hass
+        super().__init__(**kwargs)
 
     @property
     def entity_category(self):


### PR DESCRIPTION
## What

`EnergyIntegrationEntity` (`custom_components/aquarea/sensor.py:234-240`) subclasses `homeassistant.components.integration.sensor.IntegrationSensor` and picked between calling `super().__init__(**kwargs)` or `super().__init__(hass, **kwargs)` based on `AwesomeVersion(HA_VERSION) < AwesomeVersion("2025.8")`.

That assumed `hass` would remain a required constructor argument from 2025.8 onward indefinitely. **HA 2026.8.0 (released today, 2026-08-05) reverses it**: `home-assistant/core#177596` (merged 2026-07-30) removed `hass` from `IntegrationSensor.__init__` again and made every parameter keyword-only:

```python
# HA 2026.7.3
def __init__(self, hass, *, integration_method, name, ..., max_sub_interval): ...

# HA 2026.8.0
def __init__(self, *, integration_method, name, ..., max_sub_interval, device=None): ...
```

So on 2026.8+, `super().__init__(hass, **kwargs)` now raises:
```
TypeError: IntegrationSensor.__init__() takes 1 positional argument but 2 positional arguments (and 8 keyword-only arguments) were given
```

**This is not in HA's official breaking-changes list** — the core team treats these helper-entity constructors as internal API, so it won't show up in any release notes integration authors watch. It'll only surface through user bug reports once people update.

## Fix

Rather than adding a third version branch (which would need to be revisited again on the next core-internal signature change), detect at runtime whether the installed `IntegrationSensor.__init__` still accepts `hass` via `inspect.signature`, and only pass it then. This works unmodified on both sides of the 2026.8 change and needs no more `AwesomeVersion`/`HA_VERSION` tracking for this class:

```python
if "hass" in inspect.signature(IntegrationSensor.__init__).parameters:
    kwargs["hass"] = hass
super().__init__(**kwargs)
```

This is the same pattern already used elsewhere in the HACS ecosystem for this exact HA-core change:
- `bramstroker/homeassistant-powercalc` has used `inspect.signature` for this for a while.
- `nathanmarlor/foxess_modbus` uses `inspect.signature(IntegrationSensor.__init__)` explicitly (`# HA 2025.8 added 'hass' as a parameter`).
- `Olen/homeassistant-plant#500` ("version-safe construction of HA helper sensors for 2026.8") merged the same fix 2026-07-30, citing `home-assistant/core#177596/#177597/#177603`.

(Worth flagging as a trap I deliberately avoided: `gbbirkisson/gbb-ha` also calls `inspect.signature(GenericThermostat.__init__)`, but only to gate an unrelated kwarg — it still passes `hass` positionally unconditionally, so it looks defended against this but isn't. This PR's check specifically covers `hass`, and passes it as a keyword, not positionally, since positional `hass` is exactly what breaks on 2026.8's kw-only signature.)

## What I validated / didn't

- I don't have this heatpump's MQTT hardware, so I could not do an end-to-end HA runtime test.
- This repo has no test suite (`custom_components/aquarea` has no `tests/` directory, no `homeassistant` dependency pinned for local testing), so there's nothing existing to run/compare via `git stash`.
- What I *did* verify: I fetched the real `IntegrationSensor.__init__` source from `home-assistant/core` at both tag `2026.7.3` (pre-change, `hass` positional) and tag `2026.8.0` (post-change, `hass` removed, kw-only) via the GitHub API, stubbed both signatures locally, and ran the exact fixed `EnergyIntegrationEntity.__init__` logic against both — construction succeeds and `hass` is only forwarded when the base class accepts it, in both cases.
- I did not verify the `device=` kwarg IntegrationSensor gained in 2026.8 does anything useful here; this PR doesn't pass it (unchanged behavior — device linking was already independent of this constructor before).

## Diff

Minimal: only touches `EnergyIntegrationEntity.__init__` and drops the now-unused `awesomeversion`/`HA_VERSION` imports (no other use of either in this file).

Related: `kamaradclimber/geovelo-homeassistant` (same maintainer) has the identical bug in `GeoveloUtilityMeterSensor`/`UtilityMeterSensor` — companion PR: https://github.com/kamaradclimber/geovelo-homeassistant/pull/33

🤖 Generated with [Claude Code](https://claude.com/claude-code)
