### PR TITLE
Avoid taking into account incorrect values from heishamon

### DIFF
--- a/custom_components/aquarea/climate.py
+++ b/custom_components/aquarea/climate.py
@@ -308,6 +308,14 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
             topic = f"{self.discovery_prefix}commands/SetZ{self.zone_id}HeatRequestTemperature"
         else:
             topic = f"{self.discovery_prefix}commands/SetZ{self.zone_id}CoolRequestTemperature"
+
+        # Register command for retry if not confirmed
+        await self.register_command(
+            expected_value=temperature,
+            retry_callback=lambda: self.async_set_temperature(temperature=temperature),
+            tolerance=0.1,
+        )
+
         await async_publish(
             self.hass,
             topic,
@@ -317,12 +325,6 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
             "utf-8",
         )
 
-        # Register command for retry if not confirmed
-        await self.register_command(
-            expected_value=temperature,
-            retry_callback=lambda: self.async_set_temperature(temperature=temperature),
-            tolerance=0.1,
-        )
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to MQTT events."""
@@ -404,12 +406,11 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
                 if self._attr_min_temp != self.UNDEFINED_VALUE and self._attr_max_temp != self.UNDEFINED_VALUE:
                     if self._attr_target_temperature < self._attr_min_temp or self._attr_target_temperature > self._attr_max_temp:
                         # when reaching that point, maybe we should set a wider range to avoid blocking user?
-                        _LOGGER.warn(f"{self._climate_type()} Target temperature is not within expected range, this is suspicious. {self._attr_target_temperature} should be within [{self._attr_min_temp},{self._attr_max_temp}]")
+                        _LOGGER.warning(f"{self._climate_type()} Target temperature is not within expected range, this is suspicious. {self._attr_target_temperature} should be within [{self._attr_min_temp},{self._attr_max_temp}]")
 
             # Verify if this confirms a pending command
-            self.verify_command_confirmation(self._attr_target_temperature)
-
-            self.async_write_ha_state()
+            if self.verify_command_confirmation(self._attr_target_temperature):
+                self.async_write_ha_state()
 
         if self.heater:
             topic = f"{self.discovery_prefix}main/Z{self.zone_id}_Heat_Request_Temp"
@@ -450,9 +451,8 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
             self._attr_hvac_mode = guess_hvac_mode()
 
             # Verify if this confirms a pending HVAC mode change command
-            self.verify_command_confirmation(self._attr_hvac_mode)
-
-            self.async_write_ha_state()
+            if self.verify_command_confirmation(self._attr_hvac_mode):
+                self.async_write_ha_state()
 
         await mqtt.async_subscribe(
             self.hass,
@@ -483,8 +483,8 @@ class HeishaMonZoneClimate(CommandRetryMixin, ClimateEntity):
                     f"{'ON' if self._heatpump_state else 'OFF'}"
                 )
             self._attr_hvac_mode = guess_hvac_mode()
-            self.verify_command_confirmation(self._attr_hvac_mode)
-            self.async_write_ha_state()
+            if self.verify_command_confirmation(self._attr_hvac_mode):
+                self.async_write_ha_state()
 
         await mqtt.async_subscribe(
             self.hass,

--- a/custom_components/aquarea/retry_mixin.py
+++ b/custom_components/aquarea/retry_mixin.py
@@ -100,14 +100,17 @@ class CommandRetryMixin:
         # Schedule retry with jitter
         await self._schedule_retry()
 
-    def verify_command_confirmation(self, received_value: Any) -> None:
+    def verify_command_confirmation(self, received_value: Any) -> bool:
         """Verify if received state update confirms our pending command.
 
         Args:
             received_value: The value received in the state update
+        Returns:
+            True, if received value is the one we were expecting (or if we were not expecting any value)
+            False, otherwise.
         """
         if self._pending_command is None:
-            return
+            return True
 
         # Check if values match (with tolerance for numeric values)
         if self._values_match(received_value, self._pending_command.expected_value, self._pending_command.tolerance):
@@ -116,6 +119,7 @@ class CommandRetryMixin:
                 f"received: {received_value}, retries: {self._pending_command.retry_count})"
             )
             self._cancel_pending_command()
+            return True
         else:
             # Track non-matching value for diagnostic purposes
             self._pending_command.received_values.append(received_value)
@@ -123,6 +127,7 @@ class CommandRetryMixin:
                 f"{self.name}: Received value {received_value} does not match expected {self._pending_command.expected_value}, "
                 f"waiting for confirmation or retry"
             )
+            return False
 
     def _values_match(self, value1: Any, value2: Any, tolerance: Optional[float]) -> bool:
         """Check if two values match, with optional tolerance for numeric values.


### PR DESCRIPTION
This is experimental for the climate component: we don't store state if it does not correspond to the expected value.
The risk is to block changes from heishamon forever if there is a bug.

Fix #392